### PR TITLE
Added shortcut icon to index.gohtml, fixes #3

### DIFF
--- a/index.gohtml
+++ b/index.gohtml
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Quiet Hacker News</title>
+    <link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgo=">
     <style>
       body {
         padding: 20px;


### PR DESCRIPTION
This PR adds a blank shortcut icon to `index.gohtml` to prevent the browser from hitting the server with an extra request for the favicon.
Fixes #3 